### PR TITLE
Fixed the 0=1 issue and adzhosts removal

### DIFF
--- a/adkill.sh
+++ b/adkill.sh
@@ -82,43 +82,43 @@ f_load_config_file () {
 					
 		if [[ -n "$section" && -n "$enabled" && -n "$url" && -n "$msg" ]] ; then
 			if [[ "$section" = "ats" && "$ats" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "emd" && "$emd" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "exp" && "$exp" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "fsa" && "$fsa" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "grm" && "$grm" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "hfs" && "$hfs" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "hjk" && "$hjk" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "mnt" && "$mnt" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "pha" && "$pha" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "psh" && "$psh" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$section" = "wrz" && "$wrz" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$all" = 1 ]] ; then
-				"$enabled"=1
+				enabled=1
 			fi
 			if [[ "$enabled" = 1 ]] ; then
-			 f_download "$msg" "$url"
+				f_download "$msg" "$url"
 			fi
 			unset section
 			unset url

--- a/adkill.sh
+++ b/adkill.sh
@@ -145,11 +145,6 @@ msg=Downloading from pgl.yoyo.org :
 url=http://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&showintro=0&mimetype=plaintext
 enabled=1
 
-[sourceforge.net/project/adzhosts]
-msg=Downloading from downloads.sourceforge.net/project/adzhosts :
-url=http://downloads.sourceforge.net/project/adzhosts/FORADAWAY.txt
-enabled=1
-
 [ats]
 msg=Downloading from hosts-file.net : ad/tracking servers
 url=http://hosts-file.net/ad_servers.txt


### PR DESCRIPTION
Fixed the "0=1 unknow command" issue : replaced "$enabled"=1 by enabled=1 in all the advertisements hosts sources.
Remove the adzhosts section since the file is not available anymore (stopped project) and generates a download error (404).